### PR TITLE
Use `gcloud app` instead of `gcloud preview app`

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ To deploy the application:
    or using the new [gcloud SDK](https://cloud.google.com/sdk/?hl=en) commands. If you want to use the gcloud command line tool, you'll have to remove the version flag from app.yaml, which is now specified in the command line. You can also use the --version flag when deploying with appcfg.py.
    ```
    gcloud init # only required once
-   gcloud preview app deploy app.yaml --promote
+   gcloud app deploy app.yaml --promote
    ```
 
 1. Congratulations!  Your application is now live at https://your-app-id.appspot.com


### PR DESCRIPTION
We should use `gcloud app` instead of `gcloud preview app` which will go away soon.